### PR TITLE
Rename scrypt methods to a general form, fix SSE2

### DIFF
--- a/src/crypto/scrypt-sse2.cpp
+++ b/src/crypto/scrypt-sse2.cpp
@@ -94,7 +94,7 @@ static inline void xor_salsa8_sse2(__m128i B[4], const __m128i Bx[4])
 	B[3] = _mm_add_epi32(B[3], X3);
 }
 
-void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchpad)
+void scrypt_N_1_1_256_sp_sse2(const char *input, char *output, char *scratchpad, unsigned char Nfactor)
 {
 	uint8_t B[128];
 	union {
@@ -102,7 +102,7 @@ void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchp
 		uint32_t u32[32];
 	} X;
 	__m128i *V;
-	uint32_t i, j, k;
+	uint32_t i, j, k, N;
 
 	V = (__m128i *)(((uintptr_t)(scratchpad) + 63) & ~ (uintptr_t)(63));
 
@@ -114,14 +114,16 @@ void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchp
 		}
 	}
 
-	for (i = 0; i < 1024; i++) {
+	N = 1 << (Nfactor + 1);
+
+	for (i = 0; i < N; i++) {
 		for (k = 0; k < 8; k++)
 			V[i * 8 + k] = X.i128[k];
 		xor_salsa8_sse2(&X.i128[0], &X.i128[4]);
 		xor_salsa8_sse2(&X.i128[4], &X.i128[0]);
 	}
-	for (i = 0; i < 1024; i++) {
-		j = 8 * (X.u32[16] & 1023);
+	for (i = 0; i < N; i++) {
+		j = 8 * (X.u32[16] & (N - 1));
 		for (k = 0; k < 8; k++)
 			X.i128[k] = _mm_xor_si128(X.i128[k], V[j + k]);
 		xor_salsa8_sse2(&X.i128[0], &X.i128[4]);

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -3,26 +3,24 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-static const int SCRYPT_SCRATCHPAD_SIZE = 131072 + 63;
+void scrypt_N_1_1_256(const char *input, char *output, unsigned char Nfactor);
+void scrypt_N_1_1_256_sp_generic(const char *input, char *output, char *scratchpad, unsigned char Nfactor);
 
-void scrypt_1024_1_1_256(const char *input, char *output, unsigned char Nfactor);
-void scrypt_1024_1_1_256_sp_generic(const char *input, char *output, char *scratchpad, unsigned char Nfactor);
-
-/*#if defined(USE_SSE2)
+#if defined(USE_SSE2)
 #include <string>
 #if defined(_M_X64) || defined(__x86_64__) || defined(_M_AMD64) || (defined(MAC_OSX) && defined(__i386__))
 #define USE_SSE2_ALWAYS 1
-#define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_sse2((input), (output), (scratchpad))
+#define scrypt_N_1_1_256_sp(input, output, scratchpad, Nfactor) scrypt_N_1_1_256_sp_sse2((input), (output), (scratchpad), (Nfactor))
 #else
-#define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_detected((input), (output), (scratchpad))
-#endif*/
+#define scrypt_N_1_1_256_sp(input, output, scratchpad, Nfactor) scrypt_N_1_1_256_sp_detected((input), (output), (scratchpad), (Nfactor))
+#endif
 
-//std::string scrypt_detect_sse2();
-//void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchpad);
-//extern void (*scrypt_1024_1_1_256_sp_detected)(const char *input, char *output, char *scratchpad);
-//#else
-//#define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_generic((input), (output), (scratchpad))
-//#endif
+std::string scrypt_detect_sse2();
+void scrypt_N_1_1_256_sp_sse2(const char *input, char *output, char *scratchpad, unsigned char Nfactor);
+extern void (*scrypt_N_1_1_256_sp_detected)(const char *input, char *output, char *scratchpad, unsigned char Nfactor);
+#else
+#define scrypt_N_1_1_256_sp(input, output, scratchpad, Nfactor) scrypt_N_1_1_256_sp_generic((input), (output), (scratchpad), (Nfactor))
+#endif
 
 void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -37,7 +37,7 @@ uint256 CBlockHeader::GetPoWHash() const
   		unsigned char tempN = (unsigned char) n;
   		Nfactor = std::min(std::max(tempN, minNfactor), maxNfactor);
   	}
-    scrypt_1024_1_1_256(BEGIN(nVersion), BEGIN(thash), Nfactor);
+    scrypt_N_1_1_256(BEGIN(nVersion), BEGIN(thash), Nfactor);
     return thash;
 }
 

--- a/src/test/scrypt_tests.cpp
+++ b/src/test/scrypt_tests.cpp
@@ -25,12 +25,10 @@ BOOST_AUTO_TEST_CASE(scrypt_hashtest)
     for (int i = 0; i < HASHCOUNT; i++) {
         inputbytes = ParseHex(inputhex[i]);
 #if defined(USE_SSE2)
-        printf("SSE!\n");
         // Test SSE2 scrypt
         scrypt_N_1_1_256_sp_sse2((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad, Nfactor);
         BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);
 #endif
-        printf("Generic!\n");
         // Test generic scrypt
         scrypt_N_1_1_256_sp_generic((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad, Nfactor);
         BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);

--- a/src/test/scrypt_tests.cpp
+++ b/src/test/scrypt_tests.cpp
@@ -1,5 +1,7 @@
 #include <boost/test/unit_test.hpp>
 
+#include <cstdio>
+
 #include "uint256.h"
 #include "util.h"
 #include "utilstrencodings.h"
@@ -13,23 +15,27 @@ BOOST_AUTO_TEST_CASE(scrypt_hashtest)
     #define HASHCOUNT 5
     const char* inputhex[HASHCOUNT] = { "020000004c1271c211717198227392b029a64a7971931d351b387bb80db027f270411e398a07046f7d4a08dd815412a8712f874a7ebf0507e3878bd24e20a3b73fd750a667d2f451eac7471b00de6659", "0200000011503ee6a855e900c00cfdd98f5f55fffeaee9b6bf55bea9b852d9de2ce35828e204eef76acfd36949ae56d1fbe81c1ac9c0209e6331ad56414f9072506a77f8c6faf551eac7471b00389d01", "02000000a72c8a177f523946f42f22c3e86b8023221b4105e8007e59e81f6beb013e29aaf635295cb9ac966213fb56e046dc71df5b3f7f67ceaeab24038e743f883aff1aaafaf551eac7471b0166249b", "010000007824bc3a8a1b4628485eee3024abd8626721f7f870f8ad4d2f33a27155167f6a4009d1285049603888fe85a84b6c803a53305a8d497965a5e896e1a00568359589faf551eac7471b0065434e", "0200000050bfd4e4a307a8cb6ef4aef69abc5c0f2d579648bd80d7733e1ccc3fbc90ed664a7f74006cb11bde87785f229ecd366c2d4e44432832580e0608c579e4cb76f383f7f551eac7471b00c36982" };
     const char* expected[HASHCOUNT] = { "00000000002bef4107f882f6115e0b01f348d21195dacd3582aa2dabd7985806" , "00000000003a0d11bdd5eb634e08b7feddcfbbf228ed35d250daf19f1c88fc94", "00000000000b40f895f288e13244728a6c2d9d59d8aff29c65f8dd5114a8ca81", "00000000003007005891cd4923031e99d8e8d72f6e8e7edc6a86181897e105fe", "000000000018f0b426a4afc7130ccb47fa02af730d345b4fe7c7724d3800ec8c" };
-//#if defined(USE_SSE2)
-//    (void) scrypt_detect_sse2();
-//#endif
-//    uint256 scrypthash;
-//    std::vector<unsigned char> inputbytes;
-//    char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
-//    for (int i = 0; i < HASHCOUNT; i++) {
-//        inputbytes = ParseHex(inputhex[i]);
-//#if defined(USE_SSE2)
+#if defined(USE_SSE2)
+    (void) scrypt_detect_sse2();
+#endif
+    uint256 scrypthash;
+    std::vector<unsigned char> inputbytes;
+    unsigned char Nfactor = 9; // Temporary value until we can build proper tests.
+    char *scratchpad = (char*) malloc(((1 << (Nfactor + 1)) * 128 ) + 63);
+    for (int i = 0; i < HASHCOUNT; i++) {
+        inputbytes = ParseHex(inputhex[i]);
+#if defined(USE_SSE2)
+        printf("SSE!\n");
         // Test SSE2 scrypt
-//        scrypt_1024_1_1_256_sp_sse2((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad);
-//        BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);
-//#endif
+        scrypt_N_1_1_256_sp_sse2((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad, Nfactor);
+        BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);
+#endif
+        printf("Generic!\n");
         // Test generic scrypt
-        //scrypt_1024_1_1_256_sp_generic((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad);
-        //BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);
-//    }
+        scrypt_N_1_1_256_sp_generic((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad, Nfactor);
+        BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);
+    }
+    free(scratchpad);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Tests using SSE2 are also now functional, although they only test scrypt-n with an Nfactor of 9.